### PR TITLE
fix: remove obsolete hook pos check

### DIFF
--- a/orderreference.php
+++ b/orderreference.php
@@ -105,15 +105,10 @@ class Orderreference extends Module
             }
         }
 
-        $adminModulesPositionsLink = $this->context->link->getAdminLink('AdminModulesPositions');
-
-
         $this->_html .= $this->renderForm();
         $preview_reference = $this->getRandomReference();
         $this->context->smarty->assign(array(
             'preview_reference' => $preview_reference,
-            'module_position_is_hight' => $this->checkModuleHookPositionisHigh(),
-            'module_position_link' => $adminModulesPositionsLink,
         ));
         $this->_html .= $this->context->smarty->fetch($this->local_path.'views/templates/admin/configure.tpl');
         return $this->_html;
@@ -199,16 +194,5 @@ class Orderreference extends Module
     {
         $id_order = Db::getInstance()->getValue('SELECT id_order FROM '._DB_PREFIX_.'orders ORDER BY RAND()');
         return $this->getFormattedReference($id_order);
-    }
-
-    public function checkModuleHookPositionisHigh()
-    {
-        return 'orderreference' == Db::getInstance()->getValue(
-            'SELECT m.name FROM '._DB_PREFIX_.'hook h
-            LEFT JOIN '._DB_PREFIX_.'hook_module hm ON h.id_hook=hm.id_hook
-            LEFT JOIN '._DB_PREFIX_.'module m ON hm.id_module=m.id_module
-            WHERE h.name LIKE "actionValidateOrder"
-            ORDER BY hm.position'
-        );
     }
 }

--- a/views/templates/admin/configure.tpl
+++ b/views/templates/admin/configure.tpl
@@ -24,15 +24,6 @@
 *}
 
 <div class="panel">
-    {if !$module_position_is_hight}
-        <p class="alert alert-danger">
-            {l s='The position of this module is not at the top of the hook "actionValidateOrder".' mod='orderreference'}
-            <br>
-            {l s='Go to ' mod='orderreference'} <a href="{$module_position_link}" target="_blank">{$module_position_link}</a> {l s=' and search for "actionValidateOrder" and check "Display non-positionable hooks", drag the Order Reference module all the way to the top!' mod='orderreference'}
-            <br>
-            {l s='Make sure that this module\'s position is as high as possible, so that all processes happening later will find a formatted order reference!' mod='orderreference'}
-        </p>
-    {/if}
     <h2>Preview</h2>
     <p>
         <code>
@@ -46,11 +37,5 @@
             {literal}{shop->name:%1.1s:capitalize}{order->id:%06d}{/literal}
         </code>
     </p>
-    {if $module_position_is_hight}
-        <p class="alert alert-info">
-            {l s='The hook "actionValidateOrder" is configured properly.' mod='module'}
-        </p>
-    {/if}
-
 </div>
 


### PR DESCRIPTION
Removed the obsolete hook 'actionValidateOrder' position check. This is not necessary anymore after merge of #5 